### PR TITLE
feat: add path to fingerprint function

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,8 +46,8 @@ export const defineTRPCLimiter = <
   ) => {
     const options = parseOptions(opts as any, getDefaultOptions)
     const store = adapter.store(options as any)
-    const middleware: MwFn<TRoot> = async ({ ctx, next, input }) => {
-      const fp = await options.fingerprint(ctx, input)
+    const middleware: MwFn<TRoot> = async ({ ctx, next, input, path }) => {
+      const fp = await options.fingerprint(ctx, input, path)
       if (!fp) {
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,7 +40,8 @@ export type BaseOpts<TRoot extends AnyRootConfig, Res> = {
    **/
   fingerprint: (
     ctx: TRoot['_config']['$types']['ctx'],
-    input: any
+    input: any,
+    path: string
   ) => string | Promise<string>
 }
 


### PR DESCRIPTION
Adding the path to the fingerprint function would provide more flexibility to fingerprint the requests based on which procedure has been called